### PR TITLE
Provide installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Locally specific:
 # - exclude bin/ (e.g. shtest symlink)
 # - exclude generated version file
-src/bin/
+src/bin/shtest
 src/version
 
 # backups

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# posix-sh
+# sh-stdlib
 
-Stdlib for posix-compatible shells.
+A (proto) standard library for posix-compatible shells.
 
 We needed a sort of stdlib for POSIX-compatible Bourne Shell and couldn't
 find one, so we decided to set this project up.

--- a/install.sh
+++ b/install.sh
@@ -171,8 +171,7 @@ create_symlink() {
 }
 
 self_test() {
-    # TODO: Provide self-testing command and run it
-    :
+    shtest "$_SHSTDLIB_HOME/unittest/shtest" "$_SHSTDLIB_HOME/tests" | "$_SHSTDLIB_HOME/bin/tapview"
 }
 
 #: Print adequate instructions on the console.

--- a/scripts/4make/setenv.sh
+++ b/scripts/4make/setenv.sh
@@ -3,7 +3,7 @@
 SRC_DIR="$(pwd)/src"
 
 cat << EOS
-export POSIXSH_STDLIB_HOME='$SRC_DIR'; \
+export POSIXSH_STDLIB_HOME="$SRC_DIR"; \
   export PATH="$SRC_DIR/bin:\$PATH"; \
-  export POSIXSH_IMPORT_PATH='$SRC_DIR:$SRC_DIR/unittest';
+  export POSIXSH_IMPORT_PATH="$SRC_DIR:$SRC_DIR/unittest";
 EOS

--- a/src/bin/tapview
+++ b/src/bin/tapview
@@ -1,0 +1,195 @@
+#! /bin/sh
+# tapview - a TAP (Test Anything Protocol) viewer in pure POSIX shell
+#
+# Copyright by Eric S. Raymond
+#
+# This code is intended to be embedded in your project. The author
+# grants permission for it to be distributed under the prevailing
+# license of your project if you choose, provided that license is
+# OSD-compliant; otherwise the following SPDX tag incorporates a
+# license by reference.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This is version 1.1
+# A newer version may be available at https://gitlab.com/esr/tapview
+#
+# POSIX allows but does not mandate that -n suppresses emission of a
+# trailing newline in echo. Thus, some shell builtin echos don't do
+# that.  Cope gracefully.
+# shellcheck disable=SC2039
+if [ "$(echo -n "a"; echo "b")" != "ab" ]
+then
+    ECHO="echo"
+elif [ "$(/bin/echo -n "a"; /bin/echo "b")" = "ab" ]
+then
+    ECHO="/bin/echo"
+else
+    echo "tapview: bailing out, your echo lacks -n support."
+    exit 3
+fi
+
+OK="."
+FAIL="F"
+SKIP="s"
+TODO_NOT_OK="x"
+TODO_OK="u"
+
+ship_char() {
+    # shellcheck disable=SC2039
+    "${ECHO}" -n "$1"
+}
+
+ship_line() {
+    report="${report}${1}\n"
+}
+
+testcount=0
+failcount=0
+skipcount=0
+todocount=0
+test_before_plan=no
+test_after_plan=no
+expect=""
+status=0
+
+report=""
+IFS=""
+state=start
+while read -r line
+do
+    if expr "$line" : "Bail out!" >/dev/null
+    then
+	ship_line "$line"
+	status=2
+	break
+    fi
+    # Process a plan line
+    if expr "$line" : '1\.\.[0-9][0-9]*' >/dev/null
+    then
+	if [ "$expect" != "" ]
+	then
+	    if [ "${testcount}" -gt 0 ]
+	    then
+		echo ""
+	    fi
+	    ship_line "tapview: cannot have more than one plan line."
+	    echo "${report}"
+	    exit 1
+	fi
+	if expr "$line" : ".* *SKIP" >/dev/null || expr "$line" : ".* *skip" >/dev/null
+	then
+	    ship_line "$line"
+	    echo "${report}"
+	    exit 1	# Not specified in the standard whether this should exit 1 or 0
+	fi
+	expect=$(expr "$line" : '1\.\.\([0-9][0-9]*\)')
+	continue
+    fi
+    # Process an ok line
+    if expr "$line" : "ok" >/dev/null
+    then
+	testcount=$((testcount + 1))
+	if [ "$expect" = "" ]
+	then
+	    test_before_plan=yes
+	else
+	    test_after_plan=yes
+	fi
+	if expr "$line" : ".*# *TODO" >/dev/null || expr "$line" : ".*# *todo" >/dev/null
+	then
+	    ship_char ${TODO_OK}
+	    ship_line "$line"
+	    todocount=$((todocount + 1))
+	elif expr "$line" : ".*# *SKIP" >/dev/null || expr "$line" : ".*# *skip" >/dev/null
+	then
+	    ship_char ${SKIP}
+	    ship_line "$line"
+	    skipcount=$((skipcount + 1))
+	else
+	    ship_char ${OK}
+	fi
+	state=ok
+	continue
+    fi
+    # Process a not-ok line
+    if expr "$line" : "not ok" >/dev/null
+    then
+	testcount=$((testcount + 1))
+	if [ "$expect" = "" ]
+	then
+	    test_before_plan=yes
+	else
+	    test_after_plan=yes
+	fi
+	if expr "$line" : ".*# *SKIP" >/dev/null || expr "$line" : ".*# *skip" >/dev/null
+	then
+	    ship_char "${SKIP}"
+	    state=ok
+	    skipcount=$((skipcount + 1))
+	    continue
+	fi
+	if expr "$line" : ".*# *TODO" >/dev/null || expr "$line" : ".*# *todo" >/dev/null
+	then
+	    ship_char ${TODO_NOT_OK}
+	    state=ok
+	    todocount=$((todocount + 1))
+	    continue
+	fi
+	ship_char "${FAIL}"
+	ship_line "$line"
+	state=not_ok
+	failcount=$((failcount + 1))
+	status=1
+	continue
+    fi
+    # shellcheck disable=SC2166
+    if [ "${state}" = "yaml" ]
+    then
+	ship_line "$line"
+	if expr "$line" : '[ 	]*\.\.\.' >/dev/null
+	then
+	    state=ok
+	fi
+    elif expr "$line" : "[ 	]*---" >/dev/null
+    then
+	ship_line "$line"
+	state=yaml
+    fi
+done
+
+/bin/echo ""
+
+if [ -z "$expect" ]
+then
+    ship_line "Missing a plan."
+    status=1
+elif [ "$test_before_plan" = "yes" ] && [ "$test_after_plan" = "yes" ]
+then
+    ship_line "A plan line may only be placed before or after all tests."
+    status=1
+elif [ "${expect}" -gt "${testcount}" ]
+then
+    ship_line "Expected ${expect} tests but only ${testcount} ran."
+    status=1
+elif [ "${expect}" -lt "${testcount}" ]
+then
+    ship_line "Expected ${expect} tests but ${testcount} ran."
+    status=1
+fi
+
+report="${report}${testcount} tests, ${failcount} failures"
+if [ "$todocount" != 0 ]
+then
+    report="${report}, ${todocount} TODOs"
+fi
+if [ "$skipcount" != 0 ]
+then
+    report="${report}, ${skipcount} SKIPs"
+fi
+
+echo "${report}."
+
+exit "${status}"
+
+# end

--- a/src/install.sh
+++ b/src/install.sh
@@ -19,6 +19,16 @@ __version__="${1:-$__latest__}" # version passed as an argument for unreleased b
 _SHSTDLIB_FILENAME="sh-stdlib-v${__version__}.tgz"
 _URL_DOWNLOAD="https://github.com/ya55en/sh-stdlib/releases/download/v${__version__}/${_SHSTDLIB_FILENAME}"
 
+#: Terminate execution with given message and rc and.
+die() {
+    rc=$1
+    msg="$2"
+
+    _fatal "$msg" >&2
+    #echo "${C_FATAL}FATAL: $msg${C_OFF}" >&2
+    exit $rc
+}
+
 if [ "$DEBUG" = true ]; then
     echo "DEBUG: HOME='${HOME}'"
     echo "DEBUG: _SHSTDLIB_HOME='${_SHSTDLIB_HOME}'"

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,0 +1,189 @@
+#! /bin/sh
+
+#: Install sh-stdlib.
+#: sh-stdlib is a standard library for shell.
+
+_LOCAL="$HOME/.local"
+_LOCAL_SUBDIRS='bin lib opt share'
+
+# TODO: do we need to honor POSIXSH_STDLIB_HOME here?
+_SHSTDLIB_HOME="${POSIXSH_STDLIB_HOME:-${_LOCAL}/opt/sh-stdlib}"
+
+_DOWNLOAD_CACHE=/tmp
+
+_URL_LATEST=https://github.com/ya55en/sh-stdlib/releases/latest
+_URL_DOWNLOAD_RE='^location: https://github.com/ya55en/sh-stdlib/releases/tag/v\(.*\)$'
+__latest__=$(curl -Is $_URL_LATEST | grep ^location | tr -d '\n\r' | sed "s|$_URL_DOWNLOAD_RE|\1|")
+__version__="${1:-$__latest__}" # version passed as an argument for unreleased builds
+
+_SHSTDLIB_FILENAME="sh-stdlib-v${__version__}.tgz"
+_URL_DOWNLOAD="https://github.com/ya55en/sh-stdlib/releases/download/v${__version__}/${_SHSTDLIB_FILENAME}"
+
+if [ "$DEBUG" = true ]; then
+    echo "DEBUG: HOME='${HOME}'"
+    echo "DEBUG: _SHSTDLIB_HOME='${_SHSTDLIB_HOME}'"
+    echo "DEBUG: _SHSTDLIB_FILENAME='${_SHSTDLIB_FILENAME}'"
+    echo "DEBUG: _URL_DOWNLOAD='${_URL_DOWNLOAD}'"
+    echo "DEBUG: __version__='${__version__}'"
+fi
+
+#: Create ~/.local/{bin,lib,opt,share}.
+create_dot_local() {
+    if [ -e "$_LOCAL" ]; then
+        echo "W: $_LOCAL already exists, skipping."
+    else
+        echo "I: Creating directory ${_LOCAL}..."
+        mkdir -p "${_LOCAL}"
+    fi
+
+    for directory in $_LOCAL_SUBDIRS; do
+        thedir="${_LOCAL}/${directory}"
+        if [ -e "${thedir}" ]; then
+            echo "W: ${thedir} already exists, skipping."
+        else
+            echo "I: Creating ${thedir}..."
+            mkdir "${thedir}"
+        fi
+    done
+}
+
+#: Download sh-stdlib core tarball and install it.
+download_shstdlib_core() {
+    target_file_path="${_DOWNLOAD_CACHE}/${_SHSTDLIB_FILENAME}"
+    echo "install_shstdlib(): target_file_path=${target_file_path}"
+
+    if [ -e "${target_file_path}" ]; then
+        echo "Release file already downloaded, skipping."
+    else
+        echo "Downloading ${target_file_path}..."
+        curl -sL "$_URL_DOWNLOAD" -o "${target_file_path}" ||
+            die 9 "Download failed. (URL: $_URL_DOWNLOAD)"
+    fi
+}
+
+#: Install sh-stdlib into $_SHSTDLIB_HOME, creating
+#: $_SHSTDLIB_HOME/{bin,etc,lib,share/recipes}.
+install_shstdlib_core() {
+    target_file_path="${_DOWNLOAD_CACHE}/${_SHSTDLIB_FILENAME}"
+
+    if [ -e "${_SHSTDLIB_HOME}" ]; then
+        echo "Target directory already exists: ${_SHSTDLIB_HOME}, skipping."
+    else
+        echo "Deploying sh-stdlib archive to target directory ${_SHSTDLIB_HOME}..."
+        mkdir -p "${_SHSTDLIB_HOME}"
+        tar xf "${target_file_path}" -C "${_SHSTDLIB_HOME}"
+    fi
+}
+
+#: Create ~/.bashrc.d/ .
+create_bashrcd() {
+    if [ -e "$HOME/.bashrc.d" ]; then
+        echo "W: $HOME/.bashrc.d/ already exists, skipping."
+    else
+        echo "I: Creating $HOME/.bashrc.d/..."
+        mkdir "$HOME/.bashrc.d"
+    fi
+}
+
+#: Create bashrcd script ~/.bashrc.d/00-sh-stdlib-init.sh.
+create_bashrcd_script_00() {
+    target_file_path="$HOME/.bashrc.d/00-sh-stdlib-init.sh"
+
+    if [ -e "${target_file_path}" ]; then
+        echo "Bashrcd script '00-sh-stdlib-init.sh' already exists, skipping. (${target_file_path})"
+    else
+        echo "Installing bashrcd script ${target_file_path}..."
+        cat > "${target_file_path}" << EOS
+# ~/.bashrc.d/00-sh-stdlib-init.sh - sh-stdlib: initialization: first things first ;)
+
+_LOCAL="\$HOME/.local"
+_LOCAL_SHARE_APPS="\$_LOCAL/share/applications"
+
+echo "\$PATH" | grep -q "\$_LOCAL/bin" || PATH="\$_LOCAL/bin:\$PATH"
+
+# Set XDG_DATA_DIRS, if needed, so it includes user's private share section if it exists.
+# See https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html
+echo "\$XDG_DATA_DIRS" | grep -q "\$_LOCAL_SHARE_APPS" ||
+    XDG_DATA_DIRS="\$_LOCAL_SHARE_APPS:\$XDG_DATA_DIRS"
+
+EOS
+        echo "Adding POSIXSH_STDLIB_HOME setup to bashrcd script ${target_file_path}..."
+        cat >> "${target_file_path}" << EOS
+
+# sh-stdlib: set POSIXSH_STDLIB_HOME and add sh-stdlib/bin to PATH
+
+POSIXSH_STDLIB_HOME="$_SHSTDLIB_HOME" ; export POSIXSH_STDLIB_HOME
+echo \$PATH | grep -q "\$POSIXSH_STDLIB_HOME/bin" || PATH="\$POSIXSH_STDLIB_HOME/bin:\$PATH"
+EOS
+
+    fi
+}
+
+#: Create bashrcd script ~/.bashrc.d/99-sh-stdlib-import-path.sh.
+create_bashrcd_script_99_import_path() {
+    target_file_path="$HOME/.bashrc.d/99-sh-stdlib-import-path.sh"
+
+    if [ -e "${target_file_path}" ]; then
+        echo "bashrcd script '99-sh-stdlib-import-path.sh' already exists, skipping. (${target_file_path})"
+    else
+        echo "Installing bashrcd script ${target_file_path}..."
+        cat > "${target_file_path}" << EOS
+# ~/.bashrc.d/99-sh-stdlib-import-path.sh - sh-stdlib: set POSIXSH_IMPORT_PATH
+
+# POSIXSH_IMPORT_PATH is necessary for sys.sh 'import()' to work.
+echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/etc" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME/etc:\$POSIXSH_IMPORT_PATH"
+echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/lib" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME/lib:\$POSIXSH_IMPORT_PATH"
+
+export POSIXSH_IMPORT_PATH
+export PATH
+
+EOS
+    fi
+}
+
+#: Add ~/.bashrc.d/ activation code to ~/.bashrc.
+add_bashrcd_sourcing_snippet() {
+    # shellcheck disable=SC2016
+    if grep -q 'for file in "\$HOME/\.bashrc.d/"\*\.sh; do' ~/.bashrc; then
+        echo "bashrc.d sourcing snippet already set, skipping."
+    else
+        echo "Setting bashrc.d sourcing snippet..."
+        cat >> "$HOME/.bashrc" << EOS
+
+#: sh-stdlib: sourcing initializing scripts from ~/.bashrc.d/*.sh
+if [ -d "\$HOME/.bashrc.d/" ]; then
+    for file in "\$HOME/.bashrc.d/"*.sh; do
+        . "\$file"
+    done
+fi
+EOS
+    fi
+}
+
+#: Print adequate instructions on the console.
+instruct_user() {
+    cat << EOS
+
+Please close and reopen any shell-based terminals
+in order to refresh your variables.
+
+TODO: ** Instruct user what to do after installation. **
+
+TODO: Think on having a refresh-env command to reload env
+vars from ~/bashrc.d/.
+
+EOS
+}
+
+main() {
+    create_dot_local
+    download_shstdlib_core
+    install_shstdlib_core
+    create_bashrcd
+    create_bashrcd_script_00
+    create_bashrcd_script_99_import_path
+    add_bashrcd_sourcing_snippet
+    instruct_user
+}
+
+main

--- a/src/install.sh
+++ b/src/install.sh
@@ -7,7 +7,7 @@ _LOCAL="$HOME/.local"
 _LOCAL_SUBDIRS='bin lib opt share'
 
 # TODO: do we need to honor POSIXSH_STDLIB_HOME here?
-_SHSTDLIB_HOME="${POSIXSH_STDLIB_HOME:-${_LOCAL}/opt/sh-stdlib}"
+_SHSTDLIB_HOME="${POSIXSH_STDLIB_HOME:-${_LOCAL}/lib/shell/sh}"
 
 _DOWNLOAD_CACHE=/tmp
 
@@ -141,8 +141,8 @@ create_bashrcd_script_99_import_path() {
 # ~/.bashrc.d/99-sh-stdlib-import-path.sh - sh-stdlib: set POSIXSH_IMPORT_PATH
 
 # POSIXSH_IMPORT_PATH is necessary for sys.sh 'import()' to work.
-echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/etc" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME/etc:\$POSIXSH_IMPORT_PATH"
-echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/lib" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME/lib:\$POSIXSH_IMPORT_PATH"
+echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/lib" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME:\$POSIXSH_IMPORT_PATH"
+echo "\$POSIXSH_IMPORT_PATH" | grep -q "\$POSIXSH_STDLIB_HOME/lib" || POSIXSH_IMPORT_PATH="\$POSIXSH_STDLIB_HOME/unittest:\$POSIXSH_IMPORT_PATH"
 
 export POSIXSH_IMPORT_PATH
 export PATH
@@ -170,6 +170,10 @@ EOS
     fi
 }
 
+create_symlink() {
+    ln -s "$_SHSTDLIB_HOME/unittest/shtest" "$_LOCAL/bin/shtest"
+}
+
 #: Print adequate instructions on the console.
 instruct_user() {
     cat << EOS
@@ -193,6 +197,7 @@ main() {
     create_bashrcd_script_00
     create_bashrcd_script_99_import_path
     add_bashrcd_sourcing_snippet
+    create_symlink
     instruct_user
 }
 


### PR DESCRIPTION
### Provide installer script for the `sh-stdlib` package

- download and install latest `sh-stdlib` release;
- create `~/.local/` directory;
- create `~/.bashrc.d/` directory;
- alter `~/.bashrc` to source `~/.bashrc.d/*.sh` files;
- create `~/.bashrc.d/*.sh` files which set `POSIXSH_XXX` variables;
- some more tweaks.

Task: #5